### PR TITLE
fix(build): consume upstream HIPO and install networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ install
 *.o
 *.swp
 *.exe
+*.hipo
+*.h5

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,32 @@
+define call_cmake
+	cmake -B $(1)/build -S $(1) -DCMAKE_INSTALL_PREFIX=install -DCMAKE_PREFIX_PATH=$(CURDIR)/install
+	cmake --build $(1)/build
+	cmake --install $(1)/build
+endef
+
 .PHONY: eigen json fplus frugal denoising
 
 all: eigen json fplus frugal denoising
 
 eigen:
-	rm -rf build && rm -rf install && mkdir -p build install && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install ../eigen && make install
-	cd install/include && ln -s eigen3/Eigen .
+	@$(call call_cmake,$@)
+	cd install/include && ln -sf eigen3/Eigen .
 
 json:
-	rm -rf build && mkdir -p build install && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install ../json && make install
+	@$(call call_cmake,$@)
 
 fplus:
-	rm -rf build && mkdir -p build install && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install ../FunctionalPlus && make install
+	@$(call call_cmake,FunctionalPlus)
 
 frugal:
-	rm -rf build && mkdir -p build install && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install ../frugally-deep && make install
+	@$(call call_cmake,frugally-deep)
 
 clean:
-	rm -rf build install
+	rm -rf eigen/build
+	rm -rf json/build
+	rm -rf FunctionalPlus/build
+	rm -rf frugally-deep/build
+	rm -rf install
 	make -C denoising/code clean
 
 denoising:

--- a/denoising/code/Makefile
+++ b/denoising/code/Makefile
@@ -15,7 +15,9 @@ ifneq ($(HIPO_FOUND),0)
 $(error "pkg-config cannot find HIPO, or you do not have pkg-config; tried looking in $$HIPO = $(HIPO)")
 endif
 
-HIPOCFLAGS := $(shell $(HIPO_PKGCONFIG) --cflags) -I../../install/include
+INSTALL_PREFIX = $(shell cd $(CURDIR)/../../install && pwd -P)
+
+HIPOCFLAGS := $(shell $(HIPO_PKGCONFIG) --cflags) -I$(INSTALL_PREFIX)/include
 HIPOLIBS := -L$(shell $(HIPO_PKGCONFIG) --variable libdir) -l:libhipo4.a
 
 LZ4LIBS     := -llz4 -lpthread
@@ -31,8 +33,14 @@ OBJECTS2 = denoise2.o drift.o
 all:  denoise2 install
 
 install:
-	mkdir -p ../../install/bin
-	install denoise2.exe ../../install/bin
+	mkdir -p $(INSTALL_PREFIX)/bin
+	install denoise2.exe $(INSTALL_PREFIX)/bin
+	mkdir -p $(INSTALL_PREFIX)/share/denoising
+	cp -v network/*.json $(INSTALL_PREFIX)/share/denoising
+	@echo "================================="
+	@echo "done installation; you may want to set the environment variable 'DENOISING_NETWORKS' to:"
+	@echo "  $(INSTALL_PREFIX)/share/denoising"
+	@echo "================================="
 
 denoise: $(OBJECTS)
 	$(CXX) -o denoise.exe $(OBJECTS)  $(HIPOLIBS) $(LZ4LIBS)

--- a/denoising/code/Makefile
+++ b/denoising/code/Makefile
@@ -3,17 +3,22 @@
 # AUTHOR: GAVALIAN DATE: 10/24/2018
 #********************************************************
 
+# check for $HIPO_DIR environment variable
 ifndef HIPO_DIR
-$(error HIPO_DIR is not set)
-HIPO_DIR=../..
+$(error ERROR: HIPO_DIR environment variable is not set; it should point to the HIPO installation prefix)
 endif
 
-HIPOCFLAGS  := -I$(HIPO_DIR)/hipo4 -I../../install/include -I$(HIPO_DIR)/include
-#HIPOLIBS    := -L$(HIPO_DIR)/lib -lhipo4
-HIPOLIBS    := $(HIPO_DIR)/lib/libhipo4.a
+# check if pkg-config can find HIPO
+HIPO_PKGCONFIG := pkg-config --with-path $(HIPO_DIR)/lib/pkgconfig hipo4
+HIPO_FOUND := $(shell $(HIPO_PKGCONFIG); echo $$?)
+ifneq ($(HIPO_FOUND),0)
+$(error "pkg-config cannot find HIPO, or you do not have pkg-config; tried looking in $$HIPO_DIR = $(HIPO_DIR)")
+endif
 
-LZ4LIBS     := -L$(HIPO_DIR)/lz4/lib -llz4 -lpthread
-LZ4INCLUDES := -I$(HIPO_DIR)/lz4/lib
+HIPOCFLAGS := $(shell $(HIPO_PKGCONFIG) --cflags) -I../../install/include
+HIPOLIBS := -L$(shell $(HIPO_PKGCONFIG) --variable libdir) -l:libhipo4.a
+
+LZ4LIBS     := -llz4 -lpthread
 
 CXX       := g++
 CXXFLAGS  += -Wall -fPIC -std=c++17 -Wunknown-pragmas
@@ -37,7 +42,7 @@ denoise2: $(OBJECTS2)
 
 clean:
 	@echo 'Removing all build files'
-	@rm -rf *.o *~ *.exe example*hipo 
+	@rm -rf *.o *~ *.exe example*hipo
 
 %.o: %.cc
-	$(CXX) -c $< -O3 $(CXXFLAGS) $(HIPOCFLAGS) $(LZ4INCLUDES)
+	$(CXX) -c $< -O3 $(CXXFLAGS) $(HIPOCFLAGS)

--- a/denoising/code/Makefile
+++ b/denoising/code/Makefile
@@ -3,16 +3,16 @@
 # AUTHOR: GAVALIAN DATE: 10/24/2018
 #********************************************************
 
-# check for $HIPO_DIR environment variable
-ifndef HIPO_DIR
-$(error ERROR: HIPO_DIR environment variable is not set; it should point to the HIPO installation prefix)
+# check for $HIPO environment variable
+ifndef HIPO
+$(error ERROR: HIPO environment variable is not set; it should point to the HIPO installation prefix)
 endif
 
 # check if pkg-config can find HIPO
-HIPO_PKGCONFIG := pkg-config --with-path $(HIPO_DIR)/lib/pkgconfig hipo4
+HIPO_PKGCONFIG := pkg-config --with-path $(HIPO)/lib/pkgconfig hipo4
 HIPO_FOUND := $(shell $(HIPO_PKGCONFIG); echo $$?)
 ifneq ($(HIPO_FOUND),0)
-$(error "pkg-config cannot find HIPO, or you do not have pkg-config; tried looking in $$HIPO_DIR = $(HIPO_DIR)")
+$(error "pkg-config cannot find HIPO, or you do not have pkg-config; tried looking in $$HIPO = $(HIPO)")
 endif
 
 HIPOCFLAGS := $(shell $(HIPO_PKGCONFIG) --cflags) -I../../install/include

--- a/denoising/code/datastream.h
+++ b/denoising/code/datastream.h
@@ -2,9 +2,9 @@
 #ifndef __DATASTREAM__
 #define __DATASTREAM__
 
-#include "reader.h"
-#include "writer.h"
-#include "utils.h"
+#include <hipo4/reader.h>
+#include <hipo4/writer.h>
+#include <hipo4/utils.h>
 
 namespace hipo {
 

--- a/denoising/code/denoise.cc
+++ b/denoising/code/denoise.cc
@@ -15,8 +15,8 @@
 
 #include <fdeep/fdeep.hpp>
 #include "drift.h"
-#include "writer.h"
-#include "utils.h"
+#include <hipo4/writer.h>
+#include <hipo4/utils.h>
 #include "datastream.h"
 #include <thread>
 #include "cmdparser.hpp"

--- a/denoising/code/denoise2.cc
+++ b/denoising/code/denoise2.cc
@@ -15,8 +15,8 @@
 
 #include <fdeep/fdeep.hpp>
 #include "drift.h"
-#include "writer.h"
-#include "utils.h"
+#include <hipo4/writer.h>
+#include <hipo4/utils.h>
 #include "datastream.h"
 #include <thread>
 #include "cmdparser.hpp"

--- a/denoising/code/denoise2.cc
+++ b/denoising/code/denoise2.cc
@@ -129,9 +129,14 @@ void runstream(){//},std::vector<hipo::bank> *banks){//}, fdeep::model &model, s
  * @brief configure command line parser with input arguments
  */
 void configure_parser(cli::Parser& parser){
+
+  std::string default_network_path = "network";
+  if(auto path{std::getenv("DENOISING_NETWORKS")}; path != nullptr)
+    default_network_path = std::string(path);
+
   parser.set_required<std::string>("i", "input", "input file name");
   parser.set_optional<std::string>("o", "output", "output.h5", "output denoised file name");
-  parser.set_optional<std::string>("n","network","network/cnn_autoenc_0f_112.json", "neural network file name");
+  parser.set_optional<std::string>("n","network",default_network_path+std::string("/cnn_autoenc_0f_112.json"), "neural network file name");
   
   parser.set_optional<int>("t", "threads",  8,"number of threads to run");
   parser.set_optional<int>("f",  "frames", 16,"number of events in each frame");

--- a/denoising/code/drift.h
+++ b/denoising/code/drift.h
@@ -1,9 +1,9 @@
 //=============================================================
 //- 
 //=============================================================
-#include "reader.h"
+#include <hipo4/reader.h>
+#include <hipo4/event.h>
 #include <fdeep/fdeep.hpp>
-#include "event.h"
 #include <vector>
 
 #ifndef __DC_DRIFT__


### PR DESCRIPTION
The CMake and Meson HIPO installations are a bit different than the old Makefile installation. This PR:
- uses `pkg-config` to consume the HIPO library and headers, but it relies on the environment variable `$HIPO` to be set (I changed it from `$HIPO_DIR`, for consistency with `clas12-env`)
- the network `json` files are now installed, and the installation suggests to set the environment variable `$DENOISING_NETWORKS`, again for consistency with `clas12-env`
- the `cmake` commands have been fixed such that there is no assumption that the user's backend is GNU Make