### PR TITLE
fix: CMake v4 has dropped support for versions < 3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 define call_cmake
+        echo '==============='
+        echo CMAKE $(1)
+        echo '==============='
 	cmake -B $(1)/build -S $(1) -DCMAKE_INSTALL_PREFIX=install -DCMAKE_PREFIX_PATH=$(CURDIR)/install
 	cmake --build $(1)/build
 	cmake --install $(1)/build

--- a/frugally-deep/CMakeLists.txt
+++ b/frugally-deep/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(FDEEP_TOP_DIR ${CMAKE_CURRENT_LIST_DIR})
 

--- a/json/CMakeLists.txt
+++ b/json/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 ##
 ## PROJECT


### PR DESCRIPTION
Note: this PR just bumps minimum CMake version requirements in some dependency CMake files, as a _quick_ fix, hoping that this doesn't break anything.

The _correct_ solution would be to update the dependency _code_ instead, since this repository has _copies_ of dependencies within. Even better would be to _not_ have copies of dependencies here, and rely on them being externally provided by the system or container image.